### PR TITLE
Fixes CRD for k8s for v1.23.3; probably fixes it for v1.22 and v1.21

### DIFF
--- a/deploy/crds/k8s_v1alpha1_redis_crd.yaml
+++ b/deploy/crds/k8s_v1alpha1_redis_crd.yaml
@@ -6,7 +6,7 @@ spec:
   group: k8s.amaiz.com
   names:
     kind: Redis
-#    listKind: RedisList
+    listKind: RedisList
     plural: redis
     singular: redis
   scope: Namespaced

--- a/deploy/crds/k8s_v1alpha1_redis_crd.yaml
+++ b/deploy/crds/k8s_v1alpha1_redis_crd.yaml
@@ -1,185 +1,218 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: redis.k8s.amaiz.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.master
-    description: Current master's Pod name
-    name: Master
-    type: string
-  - JSONPath: .status.replicas
-    description: Current number of Redis instances
-    name: Replicas
-    type: integer
-  - JSONPath: .spec.replicas
-    description: Desired number of Redis instances
-    name: Desired
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: k8s.amaiz.com
   names:
     kind: Redis
-    listKind: RedisList
+#    listKind: RedisList
     plural: redis
     singular: redis
   scope: Namespaced
-  subresources:
-    scale:
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-          type: object
-        spec:
-          properties:
-            affinity:
-              description: Pod affinity
-              type: object
-            annotations:
-              additionalProperties:
-                type: string
-              description: Pod annotations
-              type: object
-            config:
-              additionalProperties:
-                type: string
-              description: Config allows to pass custom Redis configuration parameters
-              type: object
-            dataVolumeClaimTemplate:
-              description: DataVolumeClaimTemplate for StatefulSet
-              type: object
-            exporter:
-              description: Exporter container specification
-              properties:
-                image:
-                  description: Image is a standard path for a Container image
-                  type: string
-                initialDelaySeconds:
-                  description: 'Number of seconds after the container has started
-                    before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                  format: int32
-                  type: integer
-                resources:
-                  description: Resources describes the compute resource requirements
-                  type: object
-                securityContext:
-                  description: SecurityContext holds security configuration that will
-                    be applied to a container
-                  type: object
-              required:
-              - image
-              type: object
-            imagePullSecrets:
-              description: 'Pod ImagePullSecrets More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
-              items:
-                type: object
-              type: array
-            initContainers:
-              description: Pod initContainers
-              items:
-                type: object
-              type: array
-            password:
-              properties:
-                secretKeyRef:
-                  description: SecretKeyRef is a reference to the Secret in the same
-                    namespace containing the password.
-                  type: object
-              required:
-              - secretKeyRef
-              type: object
-            priorityClassName:
-              description: Pod priorityClassName
-              type: string
-            redis:
-              description: Redis container specification
-              properties:
-                image:
-                  description: Image is a standard path for a Container image
-                  type: string
-                initialDelaySeconds:
-                  description: 'Number of seconds after the container has started
-                    before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                  format: int32
-                  type: integer
-                resources:
-                  description: Resources describes the compute resource requirements
-                  type: object
-                securityContext:
-                  description: SecurityContext holds security configuration that will
-                    be applied to a container
-                  type: object
-              required:
-              - image
-              type: object
-            replicas:
-              description: Replicas is a number of replicas in a Redis failover cluster
-              format: int32
-              minimum: 3
-              type: integer
-            securityContext:
-              description: Pod securityContext
-              type: object
-            serviceAccountName:
-              description: 'Pod ServiceAccountName is the name of the ServiceAccount
-                to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
-              type: string
-            nodeSelector:
-              additionalProperties:
-                type: string
-              description: NodeSelector specifies a map of key-value pairs. For the
-                pod to be eligible to run on a node, the node must have each of the
-                indicated key-value pairs as labels.
-              type: object
-            tolerations:
-              description: Pod tolerations
-              items:
-                type: object
-              type: array
-            volumes:
-              description: Volumes for StatefulSet
-              items:
-                type: object
-              type: array
-          required:
-          - replicas
-          - redis
-          type: object
-        status:
-          properties:
-            master:
-              description: Master is the current master's Pod name
-              type: string
-            replicas:
-              description: Replicas is the number of active Redis instances in the
-                replication
-              format: int64
-              type: integer
-          required:
-          - replicas
-          - master
-          type: object
-      required:
-      - spec
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    additionalPrinterColumns:
+    - jsonPath: .status.master
+      description: Current master's Pod name
+      name: Master
+      type: string
+    - jsonPath: .status.replicas
+      description: Current number of Redis instances
+      name: Replicas
+      type: integer
+    - jsonPath: .spec.replicas
+      description: Desired number of Redis instances
+      name: Desired
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+#          metadata:
+#            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+#            type: object
+          spec:
+            properties:
+              affinity:
+                description: Pod affinity
+                type: object
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Pod annotations
+                type: object
+              config:
+                additionalProperties:
+                  type: string
+                description: Config allows to pass custom Redis configuration parameters
+                type: object
+              dataVolumeClaimTemplate:
+                description: DataVolumeClaimTemplate for StatefulSet
+                type: object
+              exporter:
+                description: Exporter container specification
+                properties:
+                  image:
+                    description: Image is a standard path for a Container image
+                    type: string
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources describes the compute resource requirements
+                    type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that will
+                      be applied to a container
+                    type: object
+                required:
+                - image
+                type: object
+              imagePullSecrets:
+                description: 'Pod ImagePullSecrets More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                items:
+                  type: object
+                type: array
+              initContainers:
+                description: Pod initContainers
+                items:
+                  type: object
+                type: array
+              password:
+                properties:
+                  secretKeyRef:
+                    description: SecretKeyRef is a reference to the Secret in the same
+                      namespace containing the password.
+                    type: object
+                required:
+                - secretKeyRef
+                type: object
+              priorityClassName:
+                description: Pod priorityClassName
+                type: string
+              redis:
+                description: Redis container specification
+                properties:
+                  image:
+                    description: Image is a standard path for a Container image
+                    type: string
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  resources:
+                    description: Resources describes the compute resource requirements
+                    type: object
+                  securityContext:
+                    description: SecurityContext holds security configuration that will
+                      be applied to a container
+                    type: object
+                required:
+                - image
+                type: object
+              replicas:
+                description: Replicas is a number of replicas in a Redis failover cluster
+                format: int32
+                minimum: 3
+                type: integer
+              securityContext:
+                description: Pod securityContext
+                type: object
+              serviceAccountName:
+                description: 'Pod ServiceAccountName is the name of the ServiceAccount
+                  to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector specifies a map of key-value pairs. For the
+                  pod to be eligible to run on a node, the node must have each of the
+                  indicated key-value pairs as labels.
+                type: object
+              tolerations:
+                description: Tolerations If specified, the pod's tolerations.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              volumes:
+                description: Volumes for StatefulSet
+                items:
+                  type: object
+                type: array
+            required:
+            - replicas
+            - redis
+            type: object
+          status:
+            properties:
+              master:
+                description: Master is the current master's Pod name
+                type: string
+              replicas:
+                description: Replicas is the number of active Redis instances in the
+                  replication
+                format: int64
+                type: integer
+            required:
+            - replicas
+            - master
+            type: object


### PR DESCRIPTION
This fixes issue #42; I am not sure what version the CRD v1beta1 was deprecated.

I also had to fix an issue with tolerations, they was showing up in the statefulset as:

```
tolerations:
 - {}
 - {}
 ```
otherwise, it appears to work in v1.23.3 (under k3s)

